### PR TITLE
Exclude categories folder from navigation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2.5 (unreleased)
 ------------------
 
+- Exclude categories folder from navigation.
+  [jone]
+
 - Blog entry: use text/x-html-safe output format and only allow text/html input.
   [jone]
 

--- a/ftw/blog/eventhandlers.py
+++ b/ftw/blog/eventhandlers.py
@@ -10,7 +10,8 @@ def objectAddedHandler(obj, event):
 
     #adding a categories root object
     if not safe_hasattr(obj.aq_explicit, 'categories', False):
-        _createObjectByType('BlogCategory', obj, 'categories')
+        _createObjectByType('BlogCategory', obj, 'categories',
+                            excludeFromNav=True)
         category = getattr(obj.aq_explicit, 'categories', False)
         if category:
             category.setTitle(obj.translate(_('Categories')))


### PR DESCRIPTION
Since there is an action to the categories folder it is not necessary to show it in the navigation.
