### PR TITLE
add own scale for images in collection portlet

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add own scale for leadimage in collection portlet.
+  [tschanzt]
 
 
 1.6.0 (2014-02-03)

--- a/ftw/blog/portlets/blogentry_collection_portlet.py
+++ b/ftw/blog/portlets/blogentry_collection_portlet.py
@@ -102,7 +102,9 @@ class Renderer(base.Renderer):
 
         obj = brain.getObject()
         scale = getMultiAdapter((obj, self.request), name=u"images")
-        scaled_img = scale.scale('leadimage', scale='thumb', direction='down')
+        scaled_img = scale.scale('leadimage',
+                                 scale="blog_portlet_leadimage",
+                                 direction='down')
 
         if scaled_img:
             return scaled_img.tag()

--- a/ftw/blog/profiles/default/metadata.xml
+++ b/ftw/blog/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-    <version>1600</version>
+    <version>1601</version>
     <dependencies>
         <dependency>profile-ftw.tagging:default</dependency>
         <dependency>profile-ftw.colorbox:default</dependency>

--- a/ftw/blog/profiles/default/propertiestool.xml
+++ b/ftw/blog/profiles/default/propertiestool.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="portal_properties" meta_type="Plone Properties Tool">
+
+    <object name="imaging_properties" meta_type="Plone Property Sheet">
+        <property name="allowed_sizes" type="lines" purge="False">
+            <element value="blog_portlet_leadimage 200:100"/>
+        </property>
+    </object>
+</object>

--- a/ftw/blog/upgrades/configure.zcml
+++ b/ftw/blog/upgrades/configure.zcml
@@ -87,5 +87,13 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <upgrade-step:importProfile
+        title="Add image scale"
+        profile="ftw.blog:default"
+        source="1600"
+        destination="1601"
+        directory="profiles/1601"
+        />
+
 
 </configure>

--- a/ftw/blog/upgrades/profiles/1601/propertiestool.xml
+++ b/ftw/blog/upgrades/profiles/1601/propertiestool.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="portal_properties" meta_type="Plone Properties Tool">
+
+    <object name="imaging_properties" meta_type="Plone Property Sheet">
+        <property name="allowed_sizes" type="lines" purge="False">
+            <element value="blog_portlet_leadimage 200:100"/>
+        </property>
+    </object>
+</object>


### PR DESCRIPTION
@maethu can yo take a look at this? I made a own scale because the other scales which are in this region of size are squarish which takes up a lot of space vertically so i made a scale which is wider but not as high.
